### PR TITLE
Add disconnect listener after connecting, not before

### DIFF
--- a/test/mongoose-connection.js
+++ b/test/mongoose-connection.js
@@ -28,5 +28,5 @@ test('should reuse a connection', async t => {
   let secondConnection = connect(mongoConnectionString)
   t.truthy(typeof secondConnection, 'Promise', 'should return a promise')
   secondConnection = await secondConnection
-  t.falsy(secondConnection.isReused, 'should reuse connection')
+  t.truthy(secondConnection.isReused, 'should reuse connection')
 })


### PR DESCRIPTION
Errors of the initial connection attempt were swallowed, because the "disconnect" listeners’ process.exit() was called before the error could be logged.