### PR TITLE
Remove options from logs during connect

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,7 @@ function disconnect() {
 function connect(mongoConnectionString, options = {}) {
   // Generate options
   currentOptions = { ...defaultOptions, ...options }
-  logger.info('**** mongoose-harakiri: Connecting with these options:')
-  logger.info('**** mongoose-harakiri:', currentOptions)
+  logger.info('**** mongoose-harakiri: Connecting.')
 
   // Check if connection is already open
   if (mongoose.connection.readyState > 0) {


### PR DESCRIPTION
The options object can contain sensible information (like ssl keys and certificates) which should not be logged. In general i feel that this perticular log does not really provide any value and should be removed without replacement.